### PR TITLE
fix: address pnpm security audit vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.0.18"
   },
-    "lint-staged": {
+  "lint-staged": {
     "*.ts": [
       "eslint --cache --fix"
     ],
@@ -101,8 +101,9 @@
       "minimatch": ">=9.0.7",
       "serialize-javascript": ">=7.0.3",
       "ajv": ">=8.18.0",
-      "lodash-es": ">=4.17.23",
-      "@tootallnate/once": ">=3.0.1"
+      "lodash-es": ">=4.18.0",
+      "@tootallnate/once": ">=3.0.1",
+      "dompurify": ">=3.4.0"
     }
   }
 }


### PR DESCRIPTION
## Security audit fixes

Vulnerabilities reported by `pnpm audit` and addressed in this PR. Fix strategy proposed by OpenAI `o4-mini`.

### Transitive overrides via `pnpm.overrides`

- **lodash-es** pinned to `>=4.18.0`
  _Transitive dependency not declared in dependencies or devDependencies, pin via pnpm.overrides to patched version_
- **lodash-es** pinned to `>=4.18.0`
  _Transitive dependency not declared in dependencies or devDependencies, pin via pnpm.overrides to patched version_
- **dompurify** pinned to `>=3.4.0`
  _Transitive dependency not declared in dependencies or devDependencies, pin via pnpm.overrides to patched version_
