### PR TITLE
fix: address pnpm security audit vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
       "ajv": ">=8.18.0",
       "lodash-es": ">=4.18.0",
       "@tootallnate/once": ">=3.0.1",
-      "dompurify": ">=3.4.0"
+      "dompurify": ">=3.4.0",
+      "uuid": ">=11.1.1"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   lodash-es: '>=4.18.0'
   '@tootallnate/once': '>=3.0.1'
   dompurify: '>=3.4.0'
+  uuid: '>=11.1.1'
 
 importers:
 
@@ -6596,8 +6597,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -12382,7 +12383,7 @@ snapshots:
       roughjs: 4.6.6
       stylis: 4.3.6
       ts-dedent: 2.2.0
-      uuid: 11.1.0
+      uuid: 14.0.0
     optional: true
 
   micromatch@4.0.8:
@@ -13859,7 +13860,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@11.1.0:
+  uuid@14.0.0:
     optional: true
 
   v8-compile-cache-lib@3.0.1: {}


### PR DESCRIPTION
## Security audit fixes

Vulnerabilities reported by `pnpm audit` and addressed in this PR. Fix strategy proposed by OpenAI `o4-mini`.

### Transitive overrides via `pnpm.overrides`

- **uuid** pinned to `>=11.1.1`
  _uuid is a transitive dependency, pin via overrides to satisfy patchedVersions for CVE-2026-41907_
